### PR TITLE
Update README.md - typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ android.defaultConfig.manifestPlaceholders = [
         twitterConsumerSecret: "your twitter consumer secret",
         instagramClientId    : "your instagram client id",
         instagramClientSecret: "your instagram client secret",
-        instagramRedirectUri : "your instagram redirect uri"
+        instagramRedirectUrl : "your instagram redirect uri"
 ]
 ```
 


### PR DESCRIPTION
typo in manifestPlaceholders key - should be instagramRedirectUrl, instead of instagramRedirectUri